### PR TITLE
Fixing the allowed hosts config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,3 +1,3 @@
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${?APPLICATION_SECRET}
-hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.herokuapp.com"]
+play.filters.hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.herokuapp.com"]


### PR DESCRIPTION
The allowed hosts needed  to be put inside the filters object in the play object.